### PR TITLE
Removed the third-party libraries section due to oversized repository…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ nb-configuration.xml
 
 ### Logs ###
 .log
+
+### Third-party libraries ###
+/third-party


### PR DESCRIPTION
…. Also, it is not correct to oblige specific versions of the libraries unless strictly necessary... and for now, it is not strictly necessary.